### PR TITLE
Set unlimited concurrency for faye endpoint.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,2 @@
-if defined?(PhusionPassenger)
-  PhusionPassenger.advertised_concurrency_level = 0
-end
-
 require './app'
 run Sinatra::Application

--- a/provisioning/docker_build/ahoy-deploy.conf
+++ b/provisioning/docker_build/ahoy-deploy.conf
@@ -8,4 +8,13 @@ server {
     passenger_user app;
 
     passenger_ruby /usr/bin/ruby2.5;
+
+    # Use default concurrency for the app.
+    # But Faye can take unlimited connections (0 means unlimited)
+    # https://www.phusionpassenger.com/library/config/nginx/reference/#passenger_force_max_concurrent_requests_per_process
+    location /faye {
+      passenger_app_group_name ahoy_deploy_websockets;
+      passenger_force_max_concurrent_requests_per_process 0;
+    }
+
 }


### PR DESCRIPTION
This change scopes the concurrency to the /faye endpoint.
It used to be the entire application.